### PR TITLE
Add MidiBoard

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 | 作品名(仓库地址)                                                          | 简介                                |
 | ------------------------------------------------------------------------- | ----------------------------------- |
 | [TicTacToe 互动小游戏](https://github.com/Leooeloel/TicTacToe/tree/react) | 基于模版开发的 TicTacToe 互动小游戏 |
+| [MidiBoard](https://github.com/CorpDreams/app-midi-board) | MidiBoard - 音乐白板: 在线协同MIDI音乐制作App |
 
 关于[「RTE 2022 编程挑战赛」](https://www.agora.io/cn/rte-hackathon-2022)
 


### PR DESCRIPTION
🎹 MIDI Board - A Netless app for Musicians, MIDI makers and Music educators.
MIDI Board是一个适用于声网 Netless互动白板的插件，为音乐人、MIDI制作者以及音乐教育工作者提供MIDI文件的编辑与预览。通过本插件，可以实现多端、多用户协同的MIDI编、作曲工作并导出，也可用于线上的音乐相关教学。